### PR TITLE
fix : axios 파일 수정

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -1,26 +1,21 @@
-import axios, {AxiosError} from "axios";
-import { getCookie } from "../utils/cookies";
-import { setCookie } from "../utils/cookies";
-import { reIssueToken } from "./auth";
+import axios, { AxiosError } from 'axios';
+import { getCookie } from '../utils/cookies';
+import { setCookie } from '../utils/cookies';
+import { reIssueToken } from './auth';
 
 export const instance = axios.create({
-  baseURL: `https://dev-api.dms-dsm.com`,
+  baseURL: process.env.APP_PUBLIC_URL,
   timeout: 10000,
 });
 
 instance.interceptors.request.use(
   (config) => {
     const accessToken = getCookie('access_token');
-    const returnConfig = {
-      ...config,
-    };
     if (accessToken) {
-      // @ts-ignore
-      returnConfig.headers = {
-        Authorization: `Bearer ${accessToken}`,
-      };
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
-    return returnConfig;
+    return config;
   },
   (error: AxiosError) => Promise.reject(error),
 );
@@ -29,7 +24,7 @@ instance.interceptors.response.use(
   (response) => response,
   async (error: AxiosError<AxiosError>) => {
     if (axios.isAxiosError(error) && error.response) {
-      const {config} = error;
+      const { config } = error;
       const refreshToken = getCookie('refresh_token');
       if (error.response.data.message === 'Expired Token') {
         if (refreshToken) {
@@ -47,8 +42,8 @@ instance.interceptors.response.use(
             });
 
             if (config?.headers)
-              config.headers['Authorization'] = `Bearer ${res.access_token}`
-            
+              config.headers['Authorization'] = `Bearer ${res.access_token}`;
+
             return axios(config!);
           } catch (error) {
             return Promise.reject(error);
@@ -61,5 +56,5 @@ instance.interceptors.response.use(
       }
     }
     return Promise.reject(error);
-  }
+  },
 );

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -4,7 +4,7 @@ import { setCookie } from '../utils/cookies';
 import { reIssueToken } from './auth';
 
 export const instance = axios.create({
-  baseURL: process.env.APP_PUBLIC_URL,
+  baseURL: process.env.REACT_APP_BASE_URL,
   timeout: 10000,
 });
 


### PR DESCRIPTION
axios 요청 인터셉터에서 Authorization 헤더를 설정할 때, 기존 헤더 객체를 새로 할당하여 다른 필수 헤더(Content-Type 등)가 유실되는 문제가 있었습니다.

이로 인해 특히 안드로이드 웹뷰 환경에서 net::ERR_BLOCKED_BY_RESPONSE 오류가 발생할 수 있습니다.
기존 헤더를 유지하면서 Authorization 헤더만 추가하도록 로직을 수정하여 이 문제를 해결했습니다.